### PR TITLE
Enable tRNA prediction with MITOS2

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -98,8 +98,6 @@ annotate <- function(
     dplyr::arrange(contig, pos1)
 
 
-
-
   # Rotate assembly and annotation if circular
   if(stringr::str_detect(names(assembly), "circular")){
     rotate_results <- rotate_asmb(

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -26,7 +26,7 @@ annotate <- function(
     genetic_code = "2",
     ref_db = "Chordata",
     ref_dir = "/home/harpua/Jzonah/MitoPilot/ref_dbs/Mitos2",
-    mitos_opts = "--intron 0 --oril 0 --trna 0",
+    mitos_opts = "--intron 0 --oril 0",
     mitos_condaenv = "mitos",
     trnaScan_opts = "-M vert",
     trnaScan_condaenv = "base",

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -93,8 +93,8 @@ annotate <- function(
     annotations_trnaScan,
     annotations_mitos
   ) |> dplyr::select(-dplyr::any_of('tRNA_ID')) |> # remove temporary tRNA_ID column
-    dplyr::mutate(across('gene', str_replace, 'trnS1|tnrS2', 'trnS')) |> # Rename trnS1 and trnS2 to trnS
-    dplyr::mutate(across('gene', str_replace, 'trnL1|trnL2', 'trnL')) |> # Rename trnL1 and trnL2 to trnL
+    dplyr::mutate(dplyr::across('gene', str_replace, 'trnS1|tnrS2', 'trnS')) |> # Rename trnS1 and trnS2 to trnS
+    dplyr::mutate(dplyr::across('gene', str_replace, 'trnL1|trnL2', 'trnL')) |> # Rename trnL1 and trnL2 to trnL
     dplyr::arrange(contig, pos1)
 
 

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -88,11 +88,13 @@ annotate <- function(
 
   # Combine annotations ----
   # If there are overlapping tRNA annotations, only keep the annotation from trnascan
-  annotations_mitos <- annotations_mitos[!(annotations_mitos$gene %in% annotations_trnaScan$gene),]
+  annotations_mitos <- annotations_mitos[!(annotations_mitos$tRNA_ID %in% annotations_trnaScan$tRNA_ID),]
   annotations <- dplyr::bind_rows(
     annotations_trnaScan,
     annotations_mitos
-  ) |>
+  ) |> dplyr::select(-dplyr::any_of('tRNA_ID')) |> # remove temporary tRNA_ID column
+    dplyr::mutate(across('gene', str_replace, 'trnS1|tnrS2', 'trnS')) |> # Rename trnS1 and trnS2 to trnS
+    dplyr::mutate(across('gene', str_replace, 'trnL1|trnL2', 'trnL')) |> # Rename trnL1 and trnL2 to trnL
     dplyr::arrange(contig, pos1)
 
 

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -87,11 +87,15 @@ annotate <- function(
   )
 
   # Combine annotations ----
+  # If there are overlapping tRNA annotations, only keep the annotation from trnascan
+  annotations_mitos <- annotations_mitos[!(annotations_mitos$gene %in% annotations_trnaScan$gene),]
   annotations <- dplyr::bind_rows(
     annotations_trnaScan,
     annotations_mitos
   ) |>
     dplyr::arrange(contig, pos1)
+
+
 
 
   # Rotate assembly and annotation if circular

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -93,8 +93,8 @@ annotate <- function(
     annotations_trnaScan,
     annotations_mitos
   ) |> dplyr::select(-dplyr::any_of('tRNA_ID')) |> # remove temporary tRNA_ID column
-    dplyr::mutate(dplyr::across('gene', str_replace, 'trnS1|tnrS2', 'trnS')) |> # Rename trnS1 and trnS2 to trnS
-    dplyr::mutate(dplyr::across('gene', str_replace, 'trnL1|trnL2', 'trnL')) |> # Rename trnL1 and trnL2 to trnL
+    dplyr::mutate(dplyr::across('gene', stringr::str_replace, 'trnS1|tnrS2', 'trnS')) |> # Rename trnS1 and trnS2 to trnS
+    dplyr::mutate(dplyr::across('gene', stringr::str_replace, 'trnL1|trnL2', 'trnL')) |> # Rename trnL1 and trnL2 to trnL
     dplyr::arrange(contig, pos1)
 
 

--- a/R/annotate_mitos2.R
+++ b/R/annotate_mitos2.R
@@ -112,7 +112,7 @@ annotate_mitos2 <- function(
               .after = "gene"
             ) |>
             dplyr::mutate(
-              anitcodon = dplyr::case_when(
+              anticodon = dplyr::case_when(
                 type == "tRNA" ~ toupper(stringr::str_extract(stringr::str_extract(names(x), "\\S+$"), '(?<=\\()[^\\^\\)]+')), # get anticodon
                 .default = NA_character_
               ),

--- a/R/annotate_mitos2.R
+++ b/R/annotate_mitos2.R
@@ -118,6 +118,13 @@ annotate_mitos2 <- function(
               ),
               .after = "direction"
             ) |>
+            dplyr::mutate(
+              tRNA_ID = dplyr::case_when(
+                type == "tRNA" ~ paste0(product, "-", anticodon) # create temporary ID to compare with tRNAscan-SE results
+                .default = NA_character_
+              ),
+              .after = "direction"
+            ) |>
             dplyr::mutate(length = as.numeric(ifelse(pos1 < pos2,
                                                      (1 + abs(pos2 - pos1)),
                                                      ifelse(pos1 > pos2,

--- a/R/annotate_mitos2.R
+++ b/R/annotate_mitos2.R
@@ -120,7 +120,7 @@ annotate_mitos2 <- function(
             ) |>
             dplyr::mutate(
               tRNA_ID = dplyr::case_when(
-                type == "tRNA" ~ paste0(product, "-", anticodon) # create temporary ID to compare with tRNAscan-SE results
+                type == "tRNA" ~ paste0(product, "-", anticodon), # create temporary ID to compare with tRNAscan-SE results
                 .default = NA_character_
               ),
               .after = "direction"

--- a/R/annotate_mitos2.R
+++ b/R/annotate_mitos2.R
@@ -69,132 +69,141 @@ annotate_mitos2 <- function(
 
   contig_len <- length(assembly[[1]]) # NOTE: this will be problematic when we deal with fragmented assemblies
 
-   # Format Mitos Output ----
-    annotations_mitos <- list.files(out,
-                                    recursive = T,
-                                    full.names = T,
-                                    pattern = "result.fas") |>
-      purrr::map_dfr( ~ {
-        annotations <- Biostrings::readDNAStringSet(.x) |>
-          {
-            \(x)
-            data.frame(
-              contig = stringr::str_extract(names(x), "^(.*?)(?=;)"),
-              gene = stringr::str_extract(stringr::str_extract(names(x), "\\S+$"), "^[a-zA-Z0-9]+"),
-              geneId = stringr::str_extract(names(x), "\\S+$"),
-              pos1 = stringr::str_split(names(x), " *; *", simplify = T)[, 2] |>
-                stringr::str_extract("^[0-9]+") |> as.numeric(),
-              pos2 = stringr::str_split(names(x), " *; *", simplify = T)[, 2] |>
-                stringr::str_extract("[0-9]+$") |> as.numeric(),
-              direction = stringr::str_split(names(x), " *; *", simplify = T)[, 3],
-              row.names = NULL
-            ) |>
-              dplyr::mutate(
-                type = dplyr::case_when(
-                  stringr::str_detect(gene, "^rrn[L|S]") ~ "rRNA",
-                  stringr::str_detect(gene, "^Intron") ~ "intron",
-                  stringr::str_detect(gene, "^OL") ~ "OL",
-                  stringr::str_detect(gene, "^OH") ~ "ctrl",
-                  .default = "PCG"
-                ),
-                .before = "gene"
-              ) |>
-              dplyr::mutate(
-                product = dplyr::case_when(
-                  stringr::str_detect(gene, "rrnL") ~ "16S ribosomal RNA",
-                  stringr::str_detect(gene, "rrnS") ~ "12S ribosomal RNA",
-                  stringr::str_detect(gene, "OH") ~ "d-loop",
-                  type == "PCG" ~ CDS_key[gene],
-                  .default = NA_character_
-                ),
-                .after = "gene"
-              ) |>
-              dplyr::mutate(length = as.numeric(ifelse(pos1 < pos2,
-                                            (1 + abs(pos2 - pos1)),
-                                            ifelse(pos1 > pos2,
-                                                   (abs(contig_len - pos1) + abs(1 + pos2)),
-                                                   NA_character_
-                                            )
-                                          )
+  # Format Mitos Output ----
+  annotations_mitos <- list.files(out,
+                                  recursive = T,
+                                  full.names = T,
+                                  pattern = "result.fas") |>
+    purrr::map_dfr( ~ {
+      annotations <- Biostrings::readDNAStringSet(.x) |>
+        {
+          \(x)
+          data.frame(
+            contig = stringr::str_extract(names(x), "^(.*?)(?=;)"),
+            gene = stringr::str_extract(stringr::str_extract(names(x), "\\S+$"), "^[a-zA-Z0-9]+"),
+            geneId = stringr::str_extract(names(x), "\\S+$"),
+            pos1 = stringr::str_split(names(x), " *; *", simplify = T)[, 2] |>
+              stringr::str_extract("^[0-9]+") |> as.numeric(),
+            pos2 = stringr::str_split(names(x), " *; *", simplify = T)[, 2] |>
+              stringr::str_extract("[0-9]+$") |> as.numeric(),
+            direction = stringr::str_split(names(x), " *; *", simplify = T)[, 3],
+            row.names = NULL
+          ) |>
+            dplyr::mutate(
+              type = dplyr::case_when(
+                stringr::str_detect(gene, "^rrn[L|S]") ~ "rRNA",
+                stringr::str_detect(gene, "^trn") ~ "tRNA",
+                stringr::str_detect(gene, "^Intron") ~ "intron",
+                stringr::str_detect(gene, "^OL") ~ "OL",
+                stringr::str_detect(gene, "^OH") ~ "ctrl",
+                .default = "PCG"
               ),
-              .before = "direction") |>
-              dplyr::filter(
-                gene != "OH" |
-                  stringr::str_detect(geneId, "OH_0") |
-                  stringr::str_detect(geneId, "OH$")
-              ) |>
-              dplyr::rowwise() |>
-              dplyr::mutate(
-                start_codon = dplyr::case_when(
-                  type != "PCG" ~ NA_character_,
-                  direction == "+" ~ Biostrings::subseq(assembly[contig], pos1, pos1 + 2) |> as.character(),
-                  direction == "-" ~ Biostrings::subseq(assembly[contig], pos2 - 2, pos2) |>
-                    Biostrings::reverseComplement() |> as.character()
-                ),
-                stop_codon = dplyr::case_when(
-                  type != "PCG" ~ NA_character_,
-                  direction == "+" ~ {
-                    len <- dplyr::if_else(length %% 3 == 0L, 3, length %% 3)
-                    Biostrings::subseq(assembly[contig], pos2 - len + 1, pos2) |>
-                      as.character()
-                  },
-                  direction == "-" ~ {
-                    len <- dplyr::if_else(length %% 3 == 0L, 3, length %% 3)
-                    Biostrings::subseq(assembly[contig], pos1, pos1 + len - 1) |>
-                      Biostrings::reverseComplement() |>
-                      as.character()
-                  }
-                ),
-                # below code is ugly but it works
-                # dplyr::case_when() does not work because it evaluates all statements
-                # regardless of whether they are true or false
-                translation = ifelse(
-                  type == "PCG" & direction == "+" & pos1 < pos2,
+              .before = "gene"
+            ) |>
+            dplyr::mutate(
+              product = dplyr::case_when(
+                stringr::str_detect(gene, "rrnL") ~ "16S ribosomal RNA",
+                stringr::str_detect(gene, "rrnS") ~ "12S ribosomal RNA",
+                stringr::str_detect(gene, "OH") ~ "d-loop",
+                type == "tRNA" ~ paste0("tRNA-", trnA_key_MITOS[gene]),
+                type == "PCG" ~ CDS_key[gene],
+                .default = NA_character_
+              ),
+              .after = "gene"
+            ) |>
+            dplyr::mutate(
+              anitcodon = dplyr::case_when(
+                type == "tRNA" ~ toupper(stringr::str_extract(stringr::str_extract(names(x), "\\S+$"), '(?<=\\()[^\\^\\)]+')), # get anticodon
+                .default = NA_character_
+              ),
+              .after = "direction"
+            ) |>
+            dplyr::mutate(length = as.numeric(ifelse(pos1 < pos2,
+                                                     (1 + abs(pos2 - pos1)),
+                                                     ifelse(pos1 > pos2,
+                                                            (abs(contig_len - pos1) + abs(1 + pos2)),
+                                                            NA_character_
+                                                     )
+            )
+            ),
+            .before = "direction") |>
+            dplyr::filter(
+              gene != "OH" |
+                stringr::str_detect(geneId, "OH_0") |
+                stringr::str_detect(geneId, "OH$")
+            ) |>
+            dplyr::rowwise() |>
+            dplyr::mutate(
+              start_codon = dplyr::case_when(
+                type != "PCG" ~ NA_character_,
+                direction == "+" ~ Biostrings::subseq(assembly[contig], pos1, pos1 + 2) |> as.character(),
+                direction == "-" ~ Biostrings::subseq(assembly[contig], pos2 - 2, pos2) |>
+                  Biostrings::reverseComplement() |> as.character()
+              ),
+              stop_codon = dplyr::case_when(
+                type != "PCG" ~ NA_character_,
+                direction == "+" ~ {
+                  len <- dplyr::if_else(length %% 3 == 0L, 3, length %% 3)
+                  Biostrings::subseq(assembly[contig], pos2 - len + 1, pos2) |>
+                    as.character()
+                },
+                direction == "-" ~ {
+                  len <- dplyr::if_else(length %% 3 == 0L, 3, length %% 3)
+                  Biostrings::subseq(assembly[contig], pos1, pos1 + len - 1) |>
+                    Biostrings::reverseComplement() |>
+                    as.character()
+                }
+              ),
+              # below code is ugly but it works
+              # dplyr::case_when() does not work because it evaluates all statements
+              # regardless of whether they are true or false
+              translation = ifelse(
+                type == "PCG" & direction == "+" & pos1 < pos2,
+                suppressWarnings({
+                  Biostrings::subseq(assembly[contig], pos1, pos2 - nchar(stop_codon)) |>
+                    Biostrings::translate(genetic.code = Biostrings::getGeneticCode(genetic_code)) |>
+                    as.character()
+                }),
+                ifelse(
+                  type == "PCG" & direction == "+" & pos1 > pos2,
                   suppressWarnings({
-                    Biostrings::subseq(assembly[contig], pos1, pos2 - nchar(stop_codon)) |>
+                    # this can happen if a PCG annotation wraps around the end of a circular assembly
+                    # concatenate gene chunks
+                    Biostrings::xscat(
+                      Biostrings::subseq(assembly[contig], pos1, contig_len),
+                      Biostrings::subseq(assembly[contig], 1, pos2 - nchar(stop_codon))
+                    ) |>
                       Biostrings::translate(genetic.code = Biostrings::getGeneticCode(genetic_code)) |>
                       as.character()
                   }),
                   ifelse(
-                    type == "PCG" & direction == "+" & pos1 > pos2,
+                    type == "PCG" & direction == "-" & pos1 < pos2,
                     suppressWarnings({
-                      # this can happen if a PCG annotation wraps around the end of a circular assembly
-                      # concatenate gene chunks
-                      Biostrings::xscat(
-                        Biostrings::subseq(assembly[contig], pos1, contig_len),
-                        Biostrings::subseq(assembly[contig], 1, pos2 - nchar(stop_codon))
-                      ) |>
+                      Biostrings::subseq(assembly[contig], pos1 + nchar(stop_codon), pos2) |>
+                        Biostrings::reverseComplement() |>
                         Biostrings::translate(genetic.code = Biostrings::getGeneticCode(genetic_code)) |>
                         as.character()
                     }),
                     ifelse(
-                      type == "PCG" & direction == "-" & pos1 < pos2,
+                      type == "PCG" & direction == "-" & pos1 > pos2,
                       suppressWarnings({
-                        Biostrings::subseq(assembly[contig], pos1 + nchar(stop_codon), pos2) |>
+                        #  this can happen if a PCG annotation wraps around the end of a circular assembly
+                        # concatenate gene chunks
+                        Biostrings::xscat(
+                          Biostrings::subseq(assembly[contig], pos1 + nchar(stop_codon), contig_len),
+                          Biostrings::subseq(assembly[contig], 1, pos2)
+                        ) |>
                           Biostrings::reverseComplement() |>
                           Biostrings::translate(genetic.code = Biostrings::getGeneticCode(genetic_code)) |>
                           as.character()
                       }),
-                      ifelse(
-                        type == "PCG" & direction == "-" & pos1 > pos2,
-                        suppressWarnings({
-                          #  this can happen if a PCG annotation wraps around the end of a circular assembly
-                          # concatenate gene chunks
-                          Biostrings::xscat(
-                            Biostrings::subseq(assembly[contig], pos1 + nchar(stop_codon), contig_len),
-                            Biostrings::subseq(assembly[contig], 1, pos2)
-                          ) |>
-                            Biostrings::reverseComplement() |>
-                            Biostrings::translate(genetic.code = Biostrings::getGeneticCode(genetic_code)) |>
-                            as.character()
-                        }),
-                        NA_character_
-                      )
+                      NA_character_
                     )
                   )
                 )
               )
-          }()
+            )
+        }()
 
       annotations <- annotations |>
         dplyr::select(-dplyr::any_of('geneId'))
@@ -207,21 +216,6 @@ annotate_mitos2 <- function(
 }
 
 # PCG key ----
-# CDS_key <- c(
-#   nad1 = "NADH dehydrogenase subunit 1",
-#   nad2 = "NADH dehydrogenase subunit 2",
-#   cox1 = "cytochrome c oxidase subunit 1",
-#   cox2 = "cytochrome c oxidase subunit 2",
-#   atp8 = "ATP synthase F0 subunit 8",
-#   atp6 = "ATP synthase F0 subunit 6",
-#   cox3 = "cytochrome c oxidase subunit 3",
-#   nad3 = "NADH dehydrogenase subunit 3",
-#   nad4l = "NADH dehydrogenase subunit 4L",
-#   nad4 = "NADH dehydrogenase subunit 4",
-#   nad5 = "NADH dehydrogenase subunit 5",
-#   nad6 = "NADH dehydrogenase subunit 6",
-#   cob = "cytochrome b"
-# )
 
 # PCG key for full metazoan dataset ----
 CDS_key <- c(
@@ -245,3 +239,30 @@ CDS_key <- c(
   msh1 = "MutS mismatch DNA repair protein",
   mttb = "trimethylamine methyltransferase"
 )
+
+# Key for translating tRNA codes to Amino Acid codes
+trnA_key_MITOS <- list(
+  trnF = "Phe",
+  trnV = "Val",
+  trnL1 = "Leu",
+  trnL2 = "Leu",
+  trnI = "Ile",
+  trnQ = "Gln",
+  trnM = "Met",
+  trnW = "Trp",
+  trnA = "Ala",
+  trnN = "Asn",
+  trnC = "Cys",
+  trnY = "Tyr",
+  trnS1 = "Ser",
+  trnS2 = "Ser",
+  trnD = "Asp",
+  trnK = "Lys",
+  trnG = "Gly",
+  trnR = "Arg",
+  trnH = "His",
+  trnE = "Glu",
+  trnT = "Thr",
+  trnP = "Pro"
+)
+

--- a/R/annotate_trnaScan.R
+++ b/R/annotate_trnaScan.R
@@ -110,7 +110,8 @@ annotate_trnaScan <- function(
         direction = ifelse(cur$begin < cur$end, "+", "-"),
         anticodon = cur$anticodon
       ) |>
-        dplyr::mutate(length = 1 + abs(pos2 - pos1), .before = "direction")
+        dplyr::mutate(length = 1 + abs(pos2 - pos1), .before = "direction") |>
+        dplyr::mutate(tRNA_ID = paste0(product, "-", anticodon), .after = "direction") # create temporary ID to compare with MITOS2 results
     })
 
   return({
@@ -125,7 +126,7 @@ annotate_trnaScan <- function(
 .trnA_key <- list(
   Phe = "trnF",
   Val = "trnV",
-  Leu = "trnL",
+  Leu = "trnL1",
   Ile = "trnI",
   Gln = "trnQ",
   Met = "trnM",
@@ -134,7 +135,7 @@ annotate_trnaScan <- function(
   Asn = "trnN",
   Cys = "trnC",
   Tyr = "trnY",
-  Ser = "trnS",
+  Ser = "trnS1",
   Asp = "trnD",
   Lys = "trnK",
   Gly = "trnG",

--- a/R/annotate_trnaScan.R
+++ b/R/annotate_trnaScan.R
@@ -126,7 +126,7 @@ annotate_trnaScan <- function(
 .trnA_key <- list(
   Phe = "trnF",
   Val = "trnV",
-  Leu = "trnL1",
+  Leu = "trnL",
   Ile = "trnI",
   Gln = "trnQ",
   Met = "trnM",
@@ -135,7 +135,7 @@ annotate_trnaScan <- function(
   Asn = "trnN",
   Cys = "trnC",
   Tyr = "trnY",
-  Ser = "trnS1",
+  Ser = "trnS",
   Asp = "trnD",
   Lys = "trnK",
   Gly = "trnG",

--- a/R/curate_diptera_mito.R
+++ b/R/curate_diptera_mito.R
@@ -86,50 +86,53 @@ curate_diptera_mito <- function(
 
   # rRNA ----
   ## enforce + strand ----
-  rRNA_rev <- annotations |>
-    dplyr::filter(type == "rRNA") |>
-    dplyr::filter(all(direction == "-"), .by = "contig") |>
-    dplyr::pull(contig) |>
-    unique()
-  for (seqid in rRNA_rev) {
-    wdth <- assembly[contig_key[seqid]]@ranges@width
-    annotations_updated <- annotations |>
-      dplyr::filter(contig == !!seqid) |>
-      dplyr::mutate(
-        pos1_old = pos1,
-        pos2_old = pos2,
-        pos1 = wdth - pos2_old + 1,
-        pos2 = wdth - pos1_old + 1,
-        direction = dplyr::case_match(
-          direction, "+" ~ "-", "-" ~ "+"
-        )
-      ) |>
-      dplyr::select(-pos1_old, -pos2_old)
-
-    annotations <- annotations |>
-      dplyr::filter(contig != seqid) |>
-      dplyr::bind_rows(
-        annotations_updated
-      ) |>
-      dplyr::arrange(contig, pos1)
-
-    assembly[contig_key[seqid]] <- assembly[contig_key[seqid]] |>
-      Biostrings::reverseComplement()
-
-    if (!is.null(coverage)) {
-      coverage_flip <- coverage |>
-        dplyr::filter(SeqId == !!seqid) |>
-        dplyr::arrange(desc(Position)) |>
-        dplyr::mutate(
-          Position = dplyr::row_number(),
-          Call = as.character(assembly) |> stringr::str_split("") |> unlist()
-        )
-      coverage <- dplyr::bind_rows(
-        coverage |> dplyr::filter(SeqId != seqid),
-        coverage_flip
-      )
-    }
-  }
+  # DO NOT DO THIS FOR DIPTERANS
+  # See Drosophila melanogaster reference mitogenome (GenBank NC_024511.2), rRNAs are on the negative strand
+  #
+  # rRNA_rev <- annotations |>
+  #   dplyr::filter(type == "rRNA") |>
+  #   dplyr::filter(all(direction == "-"), .by = "contig") |>
+  #   dplyr::pull(contig) |>
+  #   unique()
+  # for (seqid in rRNA_rev) {
+  #   wdth <- assembly[contig_key[seqid]]@ranges@width
+  #   annotations_updated <- annotations |>
+  #     dplyr::filter(contig == !!seqid) |>
+  #     dplyr::mutate(
+  #       pos1_old = pos1,
+  #       pos2_old = pos2,
+  #       pos1 = wdth - pos2_old + 1,
+  #       pos2 = wdth - pos1_old + 1,
+  #       direction = dplyr::case_match(
+  #         direction, "+" ~ "-", "-" ~ "+"
+  #       )
+  #     ) |>
+  #     dplyr::select(-pos1_old, -pos2_old)
+  #
+  #   annotations <- annotations |>
+  #     dplyr::filter(contig != seqid) |>
+  #     dplyr::bind_rows(
+  #       annotations_updated
+  #     ) |>
+  #     dplyr::arrange(contig, pos1)
+  #
+  #   assembly[contig_key[seqid]] <- assembly[contig_key[seqid]] |>
+  #     Biostrings::reverseComplement()
+  #
+  #   if (!is.null(coverage)) {
+  #     coverage_flip <- coverage |>
+  #       dplyr::filter(SeqId == !!seqid) |>
+  #       dplyr::arrange(desc(Position)) |>
+  #       dplyr::mutate(
+  #         Position = dplyr::row_number(),
+  #         Call = as.character(assembly) |> stringr::str_split("") |> unlist()
+  #       )
+  #     coverage <- dplyr::bind_rows(
+  #       coverage |> dplyr::filter(SeqId != seqid),
+  #       coverage_flip
+  #     )
+  #   }
+  # }
 
   ## apply punctuation model ----
   gene_idx <- which(annotations$type == "rRNA")

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -11,7 +11,7 @@ annotate(
   genetic_code = "2",
   ref_db = "Chordata",
   ref_dir = "/home/harpua/Jzonah/MitoPilot/ref_dbs/Mitos2",
-  mitos_opts = "--intron 0 --oril 0 --trna 0",
+  mitos_opts = "--intron 0 --oril 0",
   mitos_condaenv = "mitos",
   trnaScan_opts = "-M vert",
   trnaScan_condaenv = "base",


### PR DESCRIPTION
MITOS2 found some tRNAs missed by tRNAscan for dipteran tests, so:
- MITOS2 tRNA prediction now on by default, but preferentially keep tRNA annotations from tRNAscan-SE
- changed curation options for Diptera, don't enforce + strand for rRNA